### PR TITLE
Fixed dbal type name typo

### DIFF
--- a/templates/documentation/calendar_doctrine.html.twig
+++ b/templates/documentation/calendar_doctrine.html.twig
@@ -50,7 +50,7 @@ Type::addType(DateTimeTzType::NAME, DateTimeTzType::class); // aeon_datetime_tz
 doctrine:
     dbal:
         types:
-            aeon_dat: Aeon\Doctrine\Calendar\Gregorian\DayType
+            aeon_day: Aeon\Doctrine\Calendar\Gregorian\DayType
             aeon_datetime: Aeon\Doctrine\Calendar\Gregorian\DateTimeType
             aeon_datetime_tz: Aeon\Doctrine\Calendar\Gregorian\DateTimeTzType
 {% endapply %}</code></pre>


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fixed typo in dbal type name for <code>Aeon\Doctrine\Calendar\Gregorian\DayType</code></li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Make DBAL type name for `Aeon\Doctrine\Calendar\Gregorian\DayType` same as defined in `DayType::NAME` .